### PR TITLE
Playing tones implementation for buzzer driver

### DIFF
--- a/radio/src/buzzer.cpp
+++ b/radio/src/buzzer.cpp
@@ -20,46 +20,9 @@
 
 #include "opentx.h"
 
-uint8_t g_beepCnt;
-uint8_t beepAgain = 0;
-uint8_t beepAgainOrig = 0;
-uint8_t beepOn = false;
-bool warble = false;
-bool warbleC;
-
-// The various "beep" tone lengths
-static const uint8_t beepTab[]  = {
-    // key, trim, warn2, warn1, error
-    1,  1,  2, 10,  60, //xShort
-    1,  1,  4, 20,  80, //short
-    1,  1,  8, 30, 100, //normal
-    2,  2, 15, 40, 120, //long
-    5,  5, 30, 50, 150, //xLong
-};
-
-void beep(uint8_t val)
-{
-#if defined(HAPTIC)
-  // completely untested
-  if (val == 0)
-    haptic.play(5, 0, PLAY_NOW);
-  else
-    haptic.event(AU_ERROR);
-#endif
-
-  if (g_eeGeneral.alarmsFlash && val>1) {
-    flashCounter = FLASH_DURATION;
-  }
-
-  if (g_eeGeneral.beepMode>0 || (g_eeGeneral.beepMode==0 && val!=0) || (g_eeGeneral.beepMode==-1 && val>=3)) {
-    _beep(*(beepTab+5*(2+g_eeGeneral.beepLength)+val));
-  }
-}
-
-
 void pushPrompt(uint16_t value)
 {
-
+  TRACE("pushPrompt %u", value);
 }
 
 void pushCustomPrompt(uint8_t value)
@@ -71,13 +34,16 @@ void pushNumberPrompt(uint8_t value)
 {
   pushPrompt(PROMPT_I18N_BASE + value);
 }
-void pushUnit(uint8_t unit, uint8_t idx, uint8_t id){
 
+void pushUnit(uint8_t unit, uint8_t idx, uint8_t id){
+  TRACE("pushUnit %u", unit);
 }
 
 void audioEvent(unsigned int index){
-
+  TRACE("audioEvent %u", index);
 }
+
 bool isPlaying(){
+  TRACE("isPlaying");
 	return false;
 }

--- a/radio/src/buzzer.h
+++ b/radio/src/buzzer.h
@@ -39,46 +39,54 @@ extern uint8_t hapticTick;
 #endif /* HAPTIC */
 
 
-#if defined(SIMU)
-inline void _beep(uint8_t b)
-{
-	g_beepCnt = b;
-}
-#else
-inline void _beep(uint8_t b)
-{
-  buzzerSound(b);
-}
-#endif
-void beep(uint8_t val);
+// #if defined(SIMU)
+// inline void _beep(uint8_t b)
+// {
+// 	g_beepCnt = b;
+// }
+// #else
+// inline void _beep(uint8_t b)
+// {
+//   buzzerSound(b);
+// }
+// #endif
+// void beep(uint8_t val);
+void buzzerEvent(unsigned int index);
 
-
-#define AUDIO_HELLO()          PUSH_SYSTEM_PROMPT(AUDIO_HELLO)
-#define AUDIO_BYE()
-#define AUDIO_TX_BATTERY_LOW() PUSH_SYSTEM_PROMPT(AU_TX_BATTERY_LOW)
-#define AUDIO_INACTIVITY()     PUSH_SYSTEM_PROMPT(AU_INACTIVITY)
 #define AUDIO_ERROR_MESSAGE(e) PUSH_SYSTEM_PROMPT((e))
 #define AUDIO_TIMER_MINUTE(t)  playDuration(t, 0, 0)
-  // TODO
-#define AUDIO_TIMER_30()       PUSH_SYSTEM_PROMPT(AU_TIMER_30)
-#define AUDIO_TIMER_20()       PUSH_SYSTEM_PROMPT(AU_TIMER_20)
 
-#define AUDIO_KEY_PRESS()        beep(0)
-#define AUDIO_KEY_ERROR()        beep(2)
-#define AUDIO_WARNING2()         beep(2)
-#define AUDIO_WARNING1()         beep(3)
-#define AUDIO_ERROR()            beep(4)
-#define AUDIO_MIX_WARNING(x)     beep(1)
-#define AUDIO_POT_MIDDLE(x)      beep(2)
-#define AUDIO_TIMER_COUNTDOWN(idx, val)  beep(2)
-#define AUDIO_TIMER_ELAPSED(idx) beep(3)
-#define AUDIO_VARIO_UP()         _beep(1)
-#define AUDIO_VARIO_DOWN()       _beep(1)
-#define AUDIO_TRIM_PRESS(f)      { if (!IS_KEY_FIRST(event)) warble = true; beep(1); }
-#define AUDIO_TRIM_MIDDLE()      beep(2)
-#define AUDIO_TRIM_MIN()         beep(2)
-#define AUDIO_TRIM_MAX()         beep(2)
-#define AUDIO_PLAY(p)            beep(3)
+#define AUDIO_KEY_PRESS()        audioKeyPress()
+#define AUDIO_KEY_ERROR()        audioKeyError()
+
+#define AUDIO_HELLO()            PUSH_SYSTEM_PROMPT(AUDIO_HELLO)
+#define AUDIO_BYE()              
+#define AUDIO_WARNING1()         buzzerEvent(AU_WARNING1)
+#define AUDIO_WARNING2()         buzzerEvent(AU_WARNING2)
+#define AUDIO_TX_BATTERY_LOW()   buzzerEvent(AU_TX_BATTERY_LOW)
+#if defined(PCBSKY9X)
+#define AUDIO_TX_MAH_HIGH()      buzzerEvent(AU_TX_MAH_HIGH)
+#define AUDIO_TX_TEMP_HIGH()     buzzerEvent(AU_TX_TEMP_HIGH)
+#endif
+#define AUDIO_ERROR()            buzzerEvent(AU_ERROR)
+#define AUDIO_TIMER_COUNTDOWN(idx, val) audioTimerCountdown(idx, val)
+#define AUDIO_TIMER_ELAPSED(idx) buzzerEvent(AU_TIMER1_ELAPSED+idx)
+#define AUDIO_INACTIVITY()       buzzerEvent(AU_INACTIVITY)
+#define AUDIO_MIX_WARNING(x)     buzzerEvent(AU_MIX_WARNING_1+x-1)
+#define AUDIO_POT_MIDDLE(x)      buzzerEvent(AU_STICK1_MIDDLE+x)
+#define AUDIO_TRIM_MIDDLE()      buzzerEvent(AU_TRIM_MIDDLE)
+#define AUDIO_TRIM_MIN()         buzzerEvent(AU_TRIM_MIN)
+#define AUDIO_TRIM_MAX()         buzzerEvent(AU_TRIM_MAX)
+#define AUDIO_TRIM_PRESS(val)    audioTrimPress(val)
+#define AUDIO_PLAY(p)            buzzerEvent(p)
+#define AUDIO_VARIO(fq, t, p, f) playTone(fq, t, p, f)
+#define AUDIO_RSSI_ORANGE()      buzzerEvent(AU_RSSI_ORANGE)
+#define AUDIO_RSSI_RED()         buzzerEvent(AU_RSSI_RED)
+#define AUDIO_RAS_RED()          buzzerEvent(AU_RAS_RED)
+#define AUDIO_TELEMETRY_LOST()   buzzerEvent(AU_TELEMETRY_LOST)
+#define AUDIO_TELEMETRY_BACK()   buzzerEvent(AU_TELEMETRY_BACK)
+#define AUDIO_TRAINER_LOST()     buzzerEvent(AU_TRAINER_LOST)
+#define AUDIO_TRAINER_BACK()     buzzerEvent(AU_TRAINER_BACK)
 
 #define IS_AUDIO_BUSY() (g_beepCnt || beepAgain || beepOn)
 
@@ -110,16 +118,6 @@ void beep(uint8_t val);
 #define IS_PLAY_TIME()                  (0)
 #define IS_PLAYING(id)                  isPlaying()
 #define PLAY_VALUE(v, id)        		playValue((v), (id))
-
-#define AUDIO_RSSI_ORANGE()      audioEvent(AU_RSSI_ORANGE)
-#define AUDIO_RSSI_RED()         audioEvent(AU_RSSI_RED)
-#define AUDIO_RAS_RED()          audioEvent(AU_RAS_RED)
-#define AUDIO_TELEMETRY_LOST()   audioEvent(AU_TELEMETRY_LOST)
-#define AUDIO_TELEMETRY_BACK()   audioEvent(AU_TELEMETRY_BACK)
-#define AUDIO_TRAINER_LOST()     audioEvent(AU_TRAINER_LOST)
-#define AUDIO_TRAINER_BACK()     audioEvent(AU_TRAINER_BACK)
-
-#define AUDIO_VARIO(fq, t, p, f) {}
 
 #define setScaledVolume(v)
 

--- a/radio/src/buzzer.h
+++ b/radio/src/buzzer.h
@@ -38,19 +38,6 @@ extern bool warbleC;
 extern uint8_t hapticTick;
 #endif /* HAPTIC */
 
-
-// #if defined(SIMU)
-// inline void _beep(uint8_t b)
-// {
-// 	g_beepCnt = b;
-// }
-// #else
-// inline void _beep(uint8_t b)
-// {
-//   buzzerSound(b);
-// }
-// #endif
-// void beep(uint8_t val);
 void buzzerEvent(unsigned int index);
 
 #define AUDIO_ERROR_MESSAGE(e) PUSH_SYSTEM_PROMPT((e))

--- a/radio/src/gui/128x64/model_special_functions.cpp
+++ b/radio/src/gui/128x64/model_special_functions.cpp
@@ -290,7 +290,7 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
             getMixSrcRange(MIXSRC_FIRST_TIMER, val_min, val_max);
             drawTimer(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, val_displayed, attr|LEFT, attr);
           }
-#if defined(AUDIO)
+#if defined(AUDIO) || defined(BUZZER)
           else if (func == FUNC_PLAY_SOUND) {
             val_max = AU_SPECIAL_SOUND_LAST-AU_SPECIAL_SOUND_FIRST-1;
             lcdDrawTextAtIndex(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, STR_FUNCSOUNDS, val_displayed, attr);

--- a/radio/src/targets/flysky/board.cpp
+++ b/radio/src/targets/flysky/board.cpp
@@ -125,11 +125,6 @@ void referenceSystemAudioFiles()
 {
 }
 
-void setSampleRate(uint32_t frequency)
-{
-  TRACE("setSampleRate %u", frequency);
-}
-
 void watchdogInit(unsigned int duration)
 {
   IWDG->KR = 0x5555;    // Unlock registers
@@ -142,7 +137,7 @@ void watchdogInit(unsigned int duration)
 
 void initBuzzerTimer()
 {
-   PWM_TIMER->PSC = 48; // 48MHz -> 1MHz
+   PWM_TIMER->PSC = 48 - 1; // 48MHz -> 1MHz
    /* set counter mode */
    PWM_TIMER->CR1 &= ~(TIM_CR1_DIR | TIM_CR1_CMS);
    PWM_TIMER->CR1 |= TIM_CounterMode_Up;

--- a/radio/src/targets/flysky/board.h
+++ b/radio/src/targets/flysky/board.h
@@ -154,10 +154,7 @@ uint32_t sdMounted(void);
 #define SD_CARD_PRESENT()               ((SD_GPIO_PRESENT_GPIO->IDR & SD_GPIO_PRESENT_GPIO_PIN) == 0)
 #endif
 //buzzer
-void buzzerOn();
-void buzzerOff();
-void buzzerSound(uint8_t duration);
-void buzzerHeartbeat();
+#include "buzzer_driver.h"
 #define BUZZER_HEARTBEAT buzzerHeartbeat
 
 // Flash Write driver

--- a/radio/src/targets/flysky/buzzer_driver.cpp
+++ b/radio/src/targets/flysky/buzzer_driver.cpp
@@ -19,9 +19,215 @@
  */
 
 #include "opentx.h"
-#include "board.h"
+#include "buzzer_driver.h"
 
-volatile uint8_t buzzerCount;
+volatile BuzzerState buzzerState;
+BuzzerToneFifo buzzerFifo = BuzzerToneFifo();
+const BuzzerTone * nextTone = 0;
+
+void audioKeyPress()
+{
+  if (g_eeGeneral.beepMode == e_mode_all) {
+    playTone(BEEP_DEFAULT_FREQ, 40, 20, PLAY_NOW);
+  }
+}
+
+void audioKeyError()
+{
+  if (g_eeGeneral.beepMode >= e_mode_nokeys) {
+    playTone(BEEP_DEFAULT_FREQ, 160, 20, PLAY_NOW);
+  }
+}
+
+void audioTrimPress(int value)
+{
+  if (g_eeGeneral.beepMode >= e_mode_nokeys) {
+    value = limit(TRIM_MIN, value, TRIM_MAX) * 8 + 120*16;
+    playTone(value, 40, 20, PLAY_NOW);
+  }
+}
+
+void audioTimerCountdown(uint8_t timer, int value)
+{
+  if (g_model.timers[timer].countdownBeep == COUNTDOWN_BEEPS) {
+    if (value == 0) {
+      playTone(BEEP_DEFAULT_FREQ + 150, 300, 20, PLAY_NOW);
+    }
+    else if (value > 0 && value <= TIMER_COUNTDOWN_START(timer)) {
+      playTone(BEEP_DEFAULT_FREQ + 150, 100, 20, PLAY_NOW);
+    }
+    else if (value == 30) {
+      playTone(BEEP_DEFAULT_FREQ + 150, 120, 20, PLAY_REPEAT(2));
+    }
+    else if (value == 20) {
+      playTone(BEEP_DEFAULT_FREQ + 150, 120, 20, PLAY_REPEAT(1));
+    }
+    else if (value == 10) {
+      playTone(BEEP_DEFAULT_FREQ + 150, 120, 20, PLAY_NOW);
+    }
+  }
+}
+
+void buzzerEvent(unsigned int index)
+{
+  TRACE("buzzerEvent %u", index);
+  if (index == AU_NONE)
+    return;
+
+
+  if (g_eeGeneral.alarmsFlash) {
+    flashCounter = FLASH_DURATION;
+  }
+
+  if (g_eeGeneral.beepMode >= e_mode_nokeys || (g_eeGeneral.beepMode >= e_mode_alarms && index <= AU_ERROR)) {
+    switch (index) {
+      case AU_INACTIVITY:
+        playTone(2250, 80, 20, PLAY_REPEAT(2));
+        break;
+      case AU_TX_BATTERY_LOW:
+#if defined(PCBSKY9X)
+      case AU_TX_MAH_HIGH:
+      case AU_TX_TEMP_HIGH:
+#endif
+        playTone(1950, 160, 20, PLAY_REPEAT(2), 1);
+        playTone(2550, 160, 20, PLAY_REPEAT(2), -1);
+        break;
+      case AU_THROTTLE_ALERT:
+      case AU_SWITCH_ALERT:
+      case AU_ERROR:
+        playTone(BEEP_DEFAULT_FREQ, 200, 20, PLAY_NOW);
+        break;
+      case AU_TRIM_MIDDLE:
+        playTone(120*16, 80, 20, PLAY_NOW);
+        break;
+      case AU_TRIM_MIN:
+        playTone(TRIM_MIN*8 + 120*16, 80, 20, PLAY_NOW);
+        break;
+      case AU_TRIM_MAX:
+        playTone(TRIM_MAX*8 + 120*16, 80, 20, PLAY_NOW);
+        break;
+      case AU_WARNING1:
+        playTone(BEEP_DEFAULT_FREQ, 80, 20, PLAY_NOW);
+        break;
+      case AU_WARNING2:
+        playTone(BEEP_DEFAULT_FREQ, 160, 20, PLAY_NOW);
+        break;
+      case AU_WARNING3:
+        playTone(BEEP_DEFAULT_FREQ, 200, 20, PLAY_NOW);
+        break;
+        // TO.DO remove all these ones
+      case AU_STICK1_MIDDLE:
+      case AU_STICK2_MIDDLE:
+      case AU_STICK3_MIDDLE:
+      case AU_STICK4_MIDDLE:
+      case AU_POT1_MIDDLE:
+      case AU_POT2_MIDDLE:
+#if defined(PCBX9E)
+      case AU_POT3_MIDDLE:
+      case AU_POT4_MIDDLE:
+#endif
+#if defined(PCBTARANIS) || defined(PCBHORUS)
+      case AU_SLIDER1_MIDDLE:
+      case AU_SLIDER2_MIDDLE:
+#if defined(PCBX9E)
+      case AU_SLIDER3_MIDDLE:
+      case AU_SLIDER4_MIDDLE:
+#endif
+#else
+      case AU_POT3_MIDDLE:
+#endif
+        playTone(BEEP_DEFAULT_FREQ + 1500, 80, 20, PLAY_NOW);
+        break;
+      case AU_MIX_WARNING_1:
+        playTone(BEEP_DEFAULT_FREQ + 1440, 48, 32);
+        break;
+      case AU_MIX_WARNING_2:
+        playTone(BEEP_DEFAULT_FREQ + 1560, 48, 32, PLAY_REPEAT(1));
+        break;
+      case AU_MIX_WARNING_3:
+        playTone(BEEP_DEFAULT_FREQ + 1680, 48, 32, PLAY_REPEAT(2));
+        break;
+      case AU_TIMER1_ELAPSED:
+      case AU_TIMER2_ELAPSED:
+      case AU_TIMER3_ELAPSED:
+        playTone(BEEP_DEFAULT_FREQ + 150, 300, 20, PLAY_NOW);
+        break;
+      case AU_RSSI_ORANGE:
+        playTone(BEEP_DEFAULT_FREQ + 1500, 800, 20, PLAY_NOW);
+        break;
+      case AU_RSSI_RED:
+        playTone(BEEP_DEFAULT_FREQ + 1800, 800, 20, PLAY_REPEAT(1) | PLAY_NOW);
+        break;
+      case AU_RAS_RED:
+        playTone(450, 160, 40, PLAY_REPEAT(2), 1);
+        break;
+      case AU_SPECIAL_SOUND_BEEP1:
+        playTone(BEEP_DEFAULT_FREQ, 60, 20);
+        break;
+      case AU_SPECIAL_SOUND_BEEP2:
+        playTone(BEEP_DEFAULT_FREQ, 120, 20);
+        break;
+      case AU_SPECIAL_SOUND_BEEP3:
+        playTone(BEEP_DEFAULT_FREQ, 200, 20);
+        break;
+      case AU_SPECIAL_SOUND_WARN1:
+        playTone(BEEP_DEFAULT_FREQ + 600, 120, 40, PLAY_REPEAT(2));
+        break;
+      case AU_SPECIAL_SOUND_WARN2:
+        playTone(BEEP_DEFAULT_FREQ + 900, 120, 40, PLAY_REPEAT(2));
+        break;
+      case AU_SPECIAL_SOUND_CHEEP:
+        playTone(BEEP_DEFAULT_FREQ + 900, 80, 20, PLAY_REPEAT(2), 2);
+        break;
+      case AU_SPECIAL_SOUND_RING:
+        playTone(BEEP_DEFAULT_FREQ + 750, 40, 20, PLAY_REPEAT(10));
+        playTone(BEEP_DEFAULT_FREQ + 750, 40, 80, PLAY_REPEAT(1));
+        playTone(BEEP_DEFAULT_FREQ + 750, 40, 20, PLAY_REPEAT(10));
+        break;
+      case AU_SPECIAL_SOUND_SCIFI:
+        playTone(2550, 80, 20, PLAY_REPEAT(2), -1);
+        playTone(1950, 80, 20, PLAY_REPEAT(2), 1);
+        playTone(2250, 80, 20, 0);
+        break;
+      case AU_SPECIAL_SOUND_ROBOT:
+        playTone(2250, 40, 20, PLAY_REPEAT(1));
+        playTone(1650, 120, 20, PLAY_REPEAT(1));
+        playTone(2550, 120, 20, PLAY_REPEAT(1));
+        break;
+      case AU_SPECIAL_SOUND_CHIRP:
+        playTone(BEEP_DEFAULT_FREQ + 1200, 40, 20, PLAY_REPEAT(2));
+        playTone(BEEP_DEFAULT_FREQ + 1620, 40, 20, PLAY_REPEAT(3));
+        break;
+      case AU_SPECIAL_SOUND_TADA:
+        playTone(1650, 80, 40);
+        playTone(2850, 80, 40);
+        playTone(3450, 64, 36, PLAY_REPEAT(2));
+        break;
+      case AU_SPECIAL_SOUND_CRICKET:
+        playTone(2550, 40, 80, PLAY_REPEAT(3));
+        playTone(2550, 40, 160, PLAY_REPEAT(1));
+        playTone(2550, 40, 80, PLAY_REPEAT(3));
+        break;
+      case AU_SPECIAL_SOUND_SIREN:
+        playTone(450+200, 160, 40, PLAY_REPEAT(2), 2);
+        break;
+      case AU_SPECIAL_SOUND_ALARMC:
+        playTone(1650, 32, 68, PLAY_REPEAT(2));
+        playTone(2250, 64, 156, PLAY_REPEAT(1));
+        playTone(1650, 64, 76, PLAY_REPEAT(2));
+        playTone(2250, 32, 168, PLAY_REPEAT(1));
+        break;
+      case AU_SPECIAL_SOUND_RATATA:
+        playTone(BEEP_DEFAULT_FREQ + 1500, 40, 80, PLAY_REPEAT(10));
+        break;
+      case AU_SPECIAL_SOUND_TICK:
+        playTone(BEEP_DEFAULT_FREQ + 1500, 40, 400, PLAY_REPEAT(2));
+        break;
+      default:
+        break;
+    }
+  }
+}
 
 void setVolume(uint8_t volume)
 {
@@ -34,12 +240,19 @@ void setVolume(uint8_t volume)
   }
 }
 
+void setSampleRate(uint32_t frequency)
+{
+  TRACE("setSampleRate %u", frequency);
+  uint32_t timer = 1000000 / frequency - 1 ;
+
+  PWM_TIMER->CR1 &= ~TIM_CR1_CEN ;
+  PWM_TIMER->CNT = 0 ;
+  PWM_TIMER->ARR = limit<uint32_t>(2, timer, 65535) ;
+  PWM_TIMER->CR1 |= TIM_CR1_CEN ;
+}
+
 inline void buzzerOn()
 {
-  TRACE("buzzerOn beepVol %d", g_eeGeneral.beepVolume);
-
-  setVolume(g_eeGeneral.beepVolume + 2);
-
   PWM_TIMER->CR1 = TIM_CR1_CEN;
 }
 
@@ -47,19 +260,80 @@ inline void buzzerOff()
 {
   PWM_TIMER->CR1 &= ~TIM_CR1_CEN;
   PWM_TIMER->CNT = 0;                     //
-  PWM_TIMER->SR = (U16)~TIM_FLAG_Update;  // solves random quiet buzz issue when timer stopped
+  PWM_TIMER->SR = (U16)~TIM_FLAG_Update;  // solves random hiss issue when timer stopped
 }
 
-void buzzerSound(uint8_t duration)
-{
+void playTone(uint16_t freq, uint16_t len, uint16_t pause, uint8_t flags, int8_t freqIncr) {
+  TRACE("playTone freq %d, len %u, pause %u, flags %u, freqIncr %d", freq, len, pause, flags & 0x0f, freqIncr);
+
+  if (buzzerState.duration && !buzzerFifo.full()) {
+    buzzerFifo.push(BuzzerTone(freq, len, pause, flags & 0x0f, freqIncr));
+    return;
+  }
+  
+  buzzerState.freq = freq;
+  buzzerState.duration = len;
+  buzzerState.pause = pause;
+  buzzerState.repeat = flags & 0x0f;
+  buzzerState.tone.freq = freq;
+  buzzerState.tone.duration = len;
+  buzzerState.tone.pause = pause;
+  buzzerState.tone.repeat = flags & 0x0f;
+  buzzerState.tone.freqIncr = freqIncr;
+
+  setSampleRate(buzzerState.freq);
+  setVolume(g_eeGeneral.beepVolume + 2);
   buzzerOn();
-  buzzerCount = duration;
 }
 
 void buzzerHeartbeat()
 {
-  if (buzzerCount) {
-    if (--buzzerCount == 0)
+  if (buzzerState.duration) {
+
+    if (buzzerState.duration >= 10)
+      buzzerState.duration -= 10; // ms
+    else 
+      buzzerState.duration = 0;
+
+    if (buzzerState.duration == 0) {
       buzzerOff();
+
+      if (buzzerState.pause) {
+        buzzerState.duration = buzzerState.pause;
+        buzzerState.pause = 0;
+      } 
+      else if (buzzerState.repeat) {
+        buzzerState.repeat--;
+        buzzerState.freq = buzzerState.tone.freq;
+        buzzerState.duration = buzzerState.tone.duration;
+        buzzerState.pause = buzzerState.tone.pause;
+
+        setSampleRate(buzzerState.freq);
+        setVolume(g_eeGeneral.beepVolume + 2);
+        buzzerOn();
+      }
+    }
+    else if (buzzerState.tone.freqIncr) {
+      uint32_t freqChange = BUZZER_BUFFER_DURATION * buzzerState.tone.freqIncr;
+      if (freqChange > 0) {
+        buzzerState.freq += freqChange;
+        if (buzzerState.freq > BEEP_MAX_FREQ) {
+          buzzerState.freq = BEEP_MAX_FREQ;
+        }
+      }
+      else {
+        if (buzzerState.freq > BEEP_MIN_FREQ - freqChange) {
+          buzzerState.freq += freqChange;
+        }
+        else {
+          buzzerState.freq = BEEP_MIN_FREQ;
+        }
+      }
+      setSampleRate(buzzerState.freq);
+      setVolume(g_eeGeneral.beepVolume + 2);
+    }
+  } else if (!buzzerFifo.empty()) {
+    nextTone = buzzerFifo.get();
+    playTone(nextTone->freq, nextTone->duration, nextTone->pause, nextTone->repeat, nextTone->freqIncr);
   }
 }

--- a/radio/src/targets/flysky/buzzer_driver.cpp
+++ b/radio/src/targets/flysky/buzzer_driver.cpp
@@ -266,9 +266,11 @@ inline void buzzerOff()
 void playTone(uint16_t freq, uint16_t len, uint16_t pause, uint8_t flags, int8_t freqIncr) {
   TRACE("playTone freq %d, len %u, pause %u, flags %u, freqIncr %d", freq, len, pause, flags & 0x0f, freqIncr);
 
-  if (buzzerState.duration && !buzzerFifo.full()) {
-    buzzerFifo.push(BuzzerTone(freq, len, pause, flags & 0x0f, freqIncr));
-    return;
+  if (!(flags & PLAY_NOW)) {
+    if (buzzerState.duration && !buzzerFifo.full()) {
+      buzzerFifo.push(BuzzerTone(freq, len, pause, flags & 0x0f, freqIncr));
+      return;
+    }
   }
   
   buzzerState.freq = freq;

--- a/radio/src/targets/flysky/buzzer_driver.h
+++ b/radio/src/targets/flysky/buzzer_driver.h
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) OpenTX
+ *
+ * Based on code named
+ *   th9x - http://code.google.com/p/th9x 
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#ifndef _BUZZER_DRIVER_H_
+#define _BUZZER_DRIVER_H_
+
+#define BUZZER_BUFFER_DURATION  (10)
+#define BUZZER_QUEUE_LENGTH (8) // must be power of 2
+
+#define BEEP_MIN_FREQ           (250)
+#define BEEP_MAX_FREQ           (12000)
+#define BEEP_DEFAULT_FREQ       (2250)
+#define BEEP_KEY_UP_FREQ        (BEEP_DEFAULT_FREQ+150)
+#define BEEP_KEY_DOWN_FREQ      (BEEP_DEFAULT_FREQ-150)
+
+
+struct BuzzerTone {
+  uint16_t freq;
+  uint16_t duration;
+  uint16_t pause;
+  uint8_t  repeat;
+  int8_t   freqIncr;
+  BuzzerTone() {};
+  BuzzerTone(uint16_t freq, uint16_t duration, uint16_t pause, uint8_t repeat, int8_t freqIncr):
+    freq(freq),
+    duration(duration),
+    pause(pause),
+    repeat(repeat),
+    freqIncr(freqIncr)
+  {};
+};
+
+struct BuzzerState {
+  uint16_t freq;
+  uint16_t duration;
+  uint16_t pause; // current pause, set to 0 after use, reset in repeat handler
+  uint8_t repeat; // current decremented repeat
+  BuzzerTone tone;
+  BuzzerState() {};
+  BuzzerState(uint16_t freq, uint16_t duration, uint16_t pause, uint8_t repeat, BuzzerTone tone):
+    freq(freq),
+    duration(duration),
+    pause(pause),
+    repeat(repeat),
+    tone(tone)
+  {};
+};
+
+class BuzzerToneFifo
+{
+  private:
+    volatile uint8_t ridx;
+    volatile uint8_t widx;
+    BuzzerTone tones[BUZZER_QUEUE_LENGTH];
+
+    uint8_t nextIdx(uint8_t idx) const
+    {
+      return (idx + 1) & (BUZZER_QUEUE_LENGTH - 1);
+    }
+
+  public:
+    BuzzerToneFifo() : ridx(0), widx(0), tones() {};
+
+    bool empty() const
+    {
+      return ridx == widx;
+    }
+
+    bool full() const
+    {
+      return ridx == nextIdx(widx);
+    }
+
+    void clear()
+    {
+      widx = ridx;                      // clean the queue
+    }
+
+    const BuzzerTone * get()
+    {
+      if (!empty()) {
+        const BuzzerTone * tone = &tones[ridx];
+        ridx = nextIdx(ridx);
+        return tone;
+      }
+      return 0;
+    }
+
+    void push(const BuzzerTone & tone)
+    {
+      if (!full()) {
+        tones[widx] = tone;
+        widx = nextIdx(widx);
+      }
+    }
+};
+
+void buzzerEvent(unsigned int index);
+void buzzerOn();
+void buzzerOff();
+void buzzerSound(uint8_t duration);
+void audioKeyPress();
+void audioKeyError();
+void audioTrimPress(int value);
+void audioTimerCountdown(uint8_t timer, int value);
+void playTone(uint16_t freq, uint16_t len, uint16_t pause = 0, uint8_t repeat = 0, int8_t freqIncr = 0);
+void buzzerHeartbeat();
+
+#endif // _BUZZER_DRIVER_H_

--- a/radio/src/targets/flysky/hal.h
+++ b/radio/src/targets/flysky/hal.h
@@ -548,6 +548,7 @@ extern void ISR_TIMER3_CAPT_vect(void);
 #define BUZZER_GPIO_PORT GPIOA
 #define BUZZER_GPIO_PIN GPIO_Pin_8
 #define BUZZER_GPIO_PinSource GPIO_PinSource8
+#define BUZZER_RCC_APB2Periph RCC_AHBPeriph_GPIOA
 #define PWM_RCC_APB2Periph            RCC_APB2Periph_TIM1
 #define PWM_TIMER         TIM1
 #define PWM_TIMER_RCC     RCC_TIM1
@@ -572,7 +573,7 @@ extern void ISR_TIMER3_CAPT_vect(void);
 #define MIXER_SCHEDULER_TIMER_IRQHandler     TIM17_IRQHandler
 
 //all used RCC goes here
-#define RCC_AHB1_LIST                   (LCD_RCC_AHB1Periph | KEYS_RCC_AHB1Periph | RCC_AHBPeriph_GPIOB)
+#define RCC_AHB1_LIST                   (LCD_RCC_AHB1Periph | KEYS_RCC_AHB1Periph | RCC_AHBPeriph_GPIOB | BUZZER_RCC_APB2Periph)
 #define RCC_APB1_LIST                   (INTERRUPT_xMS_RCC_APB1Periph | TIMER_2MHz_RCC_APB1Periph | I2C_RCC_APB1Periph)
 #define RCC_APB2_LIST                   (MIXER_SCHEDULER_TIMER_RCC_APB1Periph | PWM_RCC_APB2Periph)
 

--- a/radio/src/targets/flysky/hal.h
+++ b/radio/src/targets/flysky/hal.h
@@ -548,7 +548,7 @@ extern void ISR_TIMER3_CAPT_vect(void);
 #define BUZZER_GPIO_PORT GPIOA
 #define BUZZER_GPIO_PIN GPIO_Pin_8
 #define BUZZER_GPIO_PinSource GPIO_PinSource8
-#define BUZZER_RCC_APB2Periph RCC_AHBPeriph_GPIOA
+#define BUZZER_RCC_AHBPeriph RCC_AHBPeriph_GPIOA
 #define PWM_RCC_APB2Periph            RCC_APB2Periph_TIM1
 #define PWM_TIMER         TIM1
 #define PWM_TIMER_RCC     RCC_TIM1
@@ -573,7 +573,7 @@ extern void ISR_TIMER3_CAPT_vect(void);
 #define MIXER_SCHEDULER_TIMER_IRQHandler     TIM17_IRQHandler
 
 //all used RCC goes here
-#define RCC_AHB1_LIST                   (LCD_RCC_AHB1Periph | KEYS_RCC_AHB1Periph | RCC_AHBPeriph_GPIOB | BUZZER_RCC_APB2Periph)
+#define RCC_AHB1_LIST                   (LCD_RCC_AHB1Periph | KEYS_RCC_AHB1Periph | RCC_AHBPeriph_GPIOB | BUZZER_RCC_AHBPeriph)
 #define RCC_APB1_LIST                   (INTERRUPT_xMS_RCC_APB1Periph | TIMER_2MHz_RCC_APB1Periph | I2C_RCC_APB1Periph)
 #define RCC_APB2_LIST                   (MIXER_SCHEDULER_TIMER_RCC_APB1Periph | PWM_RCC_APB2Periph)
 

--- a/radio/src/targets/flysky/hal.h
+++ b/radio/src/targets/flysky/hal.h
@@ -548,8 +548,6 @@ extern void ISR_TIMER3_CAPT_vect(void);
 #define BUZZER_GPIO_PORT GPIOA
 #define BUZZER_GPIO_PIN GPIO_Pin_8
 #define BUZZER_GPIO_PinSource GPIO_PinSource8
-#define BUZZER_SET_Pin GPIO_BSRR_BS_8
-#define BUZZER_RESET_Pin GPIO_BSRR_BR_8
 #define PWM_RCC_APB2Periph            RCC_APB2Periph_TIM1
 #define PWM_TIMER         TIM1
 #define PWM_TIMER_RCC     RCC_TIM1


### PR DESCRIPTION
This implementation enhances buzzer driver with proper tones handling. Acts more like audio driver when playing tones.
- Added submenu to "Beeps" in SPECIAL FUNCTIONS.
- Added playTone for buzzer.
- Added FIFO queue to do not skip important alarms.
- Vario should work, but not tested.

Whats needs to be done:
- Beep length and pitch is now obsolete so should not appear in menu.
- General battery, RSSI alarms still do not work.

Probably after small refactor can go upstream to make more people happy.