### PR TITLE
Sleep logo replaced with "Z Z Z", removes almost 0.5KB

### DIFF
--- a/radio/src/gui/128x64/widgets.cpp
+++ b/radio/src/gui/128x64/widgets.cpp
@@ -246,16 +246,22 @@ void drawProgressBar(const char * label, int num, int den)
   lcdRefresh();
 }
 
+#if !defined(PCBI6)
 const unsigned char SLEEP_BITMAP[]  = {
 #include "sleep.lbm"
 };
 
 #define SLEEP_BITMAP_WIDTH             60
 #define SLEEP_BITMAP_HEIGHT            60
+#endif
 
 void drawSleepBitmap()
 {
   lcdClear();
+#if !defined(PCBI6)
   lcdDraw1bitBitmap((LCD_W-SLEEP_BITMAP_WIDTH)/2, (LCD_H-SLEEP_BITMAP_HEIGHT)/2, SLEEP_BITMAP, 0);
+#else
+  lcdDrawText(LCD_W/2 - 12, LCD_H/2 - 4, "Z Z Z", CENTERED);
+#endif
   lcdRefresh();
 }


### PR DESCRIPTION
Sleep logo replaced with "Z Z Z", removes almost 0.5KB