### PR TITLE
ExpressLRS reboot fix

### DIFF
--- a/radio/src/gui/128x64/view_statistics.cpp
+++ b/radio/src/gui/128x64/view_statistics.cpp
@@ -273,7 +273,7 @@ void menuStatisticsDebug2(event_t event)
   }
 
   lcdDrawTextAlignedLeft(MENU_DEBUG_ROW1, "Tlm RX Err");
-  lcdDrawNumber(MENU_DEBUG_COL1_OFS, MENU_DEBUG_ROW1, telemetryErrors, RIGHT);
+  lcdDrawNumber(MENU_DEBUG_COL1_OFS + FW, MENU_DEBUG_ROW1, telemetryErrors, RIGHT);
 #if defined(BLUETOOTH)
 #if defined(PCBX7)
   lcdDrawTextAlignedLeft(MENU_DEBUG_ROW2, "BT status");

--- a/radio/src/targets/flysky/telemetry_driver.cpp
+++ b/radio/src/targets/flysky/telemetry_driver.cpp
@@ -203,9 +203,9 @@ extern "C" void TELEMETRY_USART_IRQHandler(void) {
       if (status & USART_FLAG_NE) {
         USART_ClearITPendingBit(TELEMETRY_USART, USART_FLAG_NE);
       }
-      if (status & USART_FLAG_FE) {
-        USART_ClearITPendingBit(TELEMETRY_USART, USART_FLAG_FE);
-      }
+      // if (status & USART_FLAG_FE) {
+      //   USART_ClearITPendingBit(TELEMETRY_USART, USART_FLAG_FE);
+      // }
       if (status & USART_FLAG_PE) {
         USART_ClearITPendingBit(TELEMETRY_USART, USART_FLAG_PE);
       }

--- a/radio/src/targets/flysky/telemetry_driver.cpp
+++ b/radio/src/targets/flysky/telemetry_driver.cpp
@@ -193,7 +193,7 @@ extern "C" void TELEMETRY_USART_IRQHandler(void) {
       status = TELEMETRY_USART->ISR;
     }
   }
-  while (status & (USART_FLAG_RXNE /* | USART_FLAG_ERRORS*/)) {
+  while (status & (USART_FLAG_RXNE | USART_FLAG_ERRORS)) {
     uint8_t data = TELEMETRY_USART->RDR;
     if (status & USART_FLAG_ERRORS) {
       //TRACE("%d E", status & USART_FLAG_ERRORS);

--- a/radio/src/targets/flysky/telemetry_driver.cpp
+++ b/radio/src/targets/flysky/telemetry_driver.cpp
@@ -69,8 +69,6 @@ void telemetryPortInit(uint32_t baudrate, uint8_t mode) {
 
   GPIO_PinAFConfig(TELEMETRY_GPIO, TELEMETRY_GPIO_PinSource_TX, TELEMETRY_GPIO_AF);
 
-  USART_DeInit(TELEMETRY_USART);
-  // USART_OverSampling8Cmd(TELEMETRY_USART, ENABLE);
   USART_InitStructure.USART_BaudRate = baudrate;
   if (mode & TELEMETRY_SERIAL_8E2) {
     USART_InitStructure.USART_WordLength = USART_WordLength_9b;
@@ -183,7 +181,7 @@ extern "C" void TELEMETRY_DMA_TX_IRQHandler(void) {
   }
 }
 
-#define USART_FLAG_ERRORS (USART_FLAG_ORE | USART_FLAG_NE | USART_FLAG_FE | USART_FLAG_PE)
+#define USART_FLAG_ERRORS (USART_FLAG_ORE | USART_FLAG_NE | USART_FLAG_PE) // | USART_FLAG_FE
 extern "C" void TELEMETRY_USART_IRQHandler(void) {
   DEBUG_INTERRUPT(INT_TELEM_USART);
   uint32_t status = TELEMETRY_USART->ISR;

--- a/radio/src/targets/flysky/telemetry_driver.cpp
+++ b/radio/src/targets/flysky/telemetry_driver.cpp
@@ -69,6 +69,8 @@ void telemetryPortInit(uint32_t baudrate, uint8_t mode) {
 
   GPIO_PinAFConfig(TELEMETRY_GPIO, TELEMETRY_GPIO_PinSource_TX, TELEMETRY_GPIO_AF);
 
+  USART_DeInit(TELEMETRY_USART);
+  // USART_OverSampling8Cmd(TELEMETRY_USART, ENABLE);
   USART_InitStructure.USART_BaudRate = baudrate;
   if (mode & TELEMETRY_SERIAL_8E2) {
     USART_InitStructure.USART_WordLength = USART_WordLength_9b;
@@ -209,9 +211,9 @@ extern "C" void TELEMETRY_USART_IRQHandler(void) {
       if (status & USART_FLAG_PE) {
         USART_ClearITPendingBit(TELEMETRY_USART, USART_FLAG_PE);
       }
-    }
-    //TRACE("O");
-    telemetryFifo.push(data);
+    } else {
+      //TRACE("O");
+      telemetryFifo.push(data);
 
 #if defined(LUA)
     if (telemetryProtocol == PROTOCOL_FRSKY_SPORT) {
@@ -222,7 +224,7 @@ extern "C" void TELEMETRY_USART_IRQHandler(void) {
       prevdata = data;
     }
 #endif
-
+    }
     status = TELEMETRY_USART->ISR;
   }
 }

--- a/radio/src/targets/flysky/telemetry_driver.cpp
+++ b/radio/src/targets/flysky/telemetry_driver.cpp
@@ -181,7 +181,7 @@ extern "C" void TELEMETRY_DMA_TX_IRQHandler(void) {
   }
 }
 
-#define USART_FLAG_ERRORS (USART_FLAG_ORE | USART_FLAG_NE | USART_FLAG_PE) // | USART_FLAG_FE
+#define USART_FLAG_ERRORS (USART_FLAG_ORE | USART_FLAG_PE) // | USART_FLAG_FE, USART_FLAG_NE
 extern "C" void TELEMETRY_USART_IRQHandler(void) {
   DEBUG_INTERRUPT(INT_TELEM_USART);
   uint32_t status = TELEMETRY_USART->ISR;
@@ -200,12 +200,12 @@ extern "C" void TELEMETRY_USART_IRQHandler(void) {
       if (status & USART_FLAG_ORE) {
         USART_ClearITPendingBit(TELEMETRY_USART, USART_IT_ORE);
       }
-      if (status & USART_FLAG_NE) {
-        USART_ClearITPendingBit(TELEMETRY_USART, USART_FLAG_NE);
-      }
-      // if (status & USART_FLAG_FE) {
-      //   USART_ClearITPendingBit(TELEMETRY_USART, USART_FLAG_FE);
-      // }
+//      if (status & USART_FLAG_NE) {
+//        USART_ClearITPendingBit(TELEMETRY_USART, USART_FLAG_NE);
+//      }
+//       if (status & USART_FLAG_FE) {
+//         USART_ClearITPendingBit(TELEMETRY_USART, USART_FLAG_FE);
+//       }
       if (status & USART_FLAG_PE) {
         USART_ClearITPendingBit(TELEMETRY_USART, USART_FLAG_PE);
       }

--- a/radio/src/telemetry/expresslrs.cpp
+++ b/radio/src/telemetry/expresslrs.cpp
@@ -7,9 +7,9 @@ uint16_t UartBadPkts;
 
 uint8_t SX127x_RATES_VALUES[] = {0x06, 0x05, 0x04, 0x02};
 uint8_t SX128x_RATES_VALUES[] = {0x05, 0x03, 0x01, 0x00};
-uint8_t TLM_INTERVAL_VALUES[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07};
-uint8_t MAX_POWER_VALUES[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07};
-uint8_t RF_FREQUENCY_VALUES[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
+// uint8_t TLM_INTERVAL_VALUES[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07};
+// uint8_t MAX_POWER_VALUES[] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07};
+// uint8_t RF_FREQUENCY_VALUES[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
 
 char commitSha[] = "??????";
 
@@ -30,9 +30,9 @@ void elrsProcessResponse(uint8_t len, uint8_t* data) {
     // Type 0xff - "sendLuaParams"
     if (data[2] == 0xFF) {
       if (len == 12) {
-        g_model.moduleData[EXTERNAL_MODULE].elrs.tlm_interval = findIndex(TLM_INTERVAL_VALUES, ELRS_MAX_TLM_INTERVAL, data[5]);
-        g_model.moduleData[EXTERNAL_MODULE].elrs.max_power = findIndex(MAX_POWER_VALUES, ELRS_MAX_MAX_POWER, data[6]);
-        g_model.moduleData[EXTERNAL_MODULE].elrs.rf_frequency = findIndex(RF_FREQUENCY_VALUES, ELRS_MAX_RF_FREQ, data[7]);
+        g_model.moduleData[EXTERNAL_MODULE].elrs.tlm_interval = data[5]; //findIndex(TLM_INTERVAL_VALUES, ELRS_MAX_TLM_INTERVAL, data[5]);
+        g_model.moduleData[EXTERNAL_MODULE].elrs.max_power = data[6]; //findIndex(MAX_POWER_VALUES, ELRS_MAX_MAX_POWER, data[6]);
+        g_model.moduleData[EXTERNAL_MODULE].elrs.rf_frequency = data[7] - 1; //findIndex(RF_FREQUENCY_VALUES, ELRS_MAX_RF_FREQ, data[7]);
         if (data[7] == 6) {
           g_model.moduleData[EXTERNAL_MODULE].elrs.rf_type = ELRS_RF_SX128x;
           g_model.moduleData[EXTERNAL_MODULE].elrs.pkt_rate = findIndex(SX128x_RATES_VALUES, ELRS_MAX_RATE_SX128, data[4]);
@@ -70,10 +70,10 @@ void elrsSendRequest(uint8_t request, uint8_t value) {
       }
       break;
     case ELRS_TLM_INTERVAL:
-      data[3] = TLM_INTERVAL_VALUES[value];
-      break;
+      // data[3] = value; //TLM_INTERVAL_VALUES[value];
+      // break;
     case ELRS_MAX_POWER:
-      data[3] = MAX_POWER_VALUES[value];
+      data[3] = value; //MAX_POWER_VALUES[value];
       break;
       /* not yet implemented
     case ELRS_BIND:      


### PR DESCRIPTION
Without this change on **DIY Slimmer 2.4 TX** i have reboots every 5-30 seconds. With this change I was able to stay online for over 2 hours.

Issue was: **It is impossible to clear USART_FLAG_FE in interrupt mode**, so don't handle it.

- Restored uart error clearing like on other platforms.
- ~~Seems like less likely to reboot on cold start with `USART_DeInit`.~~
- Shaved almost 100 bytes from elrs script.
- Realigned telemetry errors value.
- **Fixed John's error. (USART_FLAG_NE)**

Please test on **R9m**.