### PR TITLE
Format baud rates to make it easier to read

### DIFF
--- a/radio/src/gui/128x64/radio_hardware.cpp
+++ b/radio/src/gui/128x64/radio_hardware.cpp
@@ -237,6 +237,7 @@ void menuRadioHardware(event_t event)
             pauseMixerCalculations();
             pausePulses();
             EXTERNAL_MODULE_OFF();
+            storageDirty(EE_GENERAL);
             RTOS_WAIT_MS(20); // 20ms so that the pulses interrupt will reinit the frame rate
             telemetryProtocol = 255; // force telemetry port + module reinitialization
             EXTERNAL_MODULE_ON();

--- a/radio/src/gui/128x64/radio_hardware.cpp
+++ b/radio/src/gui/128x64/radio_hardware.cpp
@@ -229,8 +229,10 @@ void menuRadioHardware(event_t event)
       }
 
       case ITEM_RADIO_HARDWARE_SERIAL_BAUDRATE:
-        g_eeGeneral.telemetryBaudrate = editChoice(HW_SETTINGS_COLUMN2, y, STR_MAXBAUDRATE, "\004115k400k921k1.8M3.7M", g_eeGeneral.telemetryBaudrate, 0, DIM(CROSSFIRE_BAUDRATES) - 1, attr, event);
+        lcdDrawTextAlignedLeft(y, STR_MAXBAUDRATE);
+        lcdDrawTextAtIndex(HW_SETTINGS_COLUMN2, y, "\0043.7M1.8M921k400k115k", g_eeGeneral.telemetryBaudrate, attr | LEFT);
         if (attr) {
+          g_eeGeneral.telemetryBaudrate = DIM(CROSSFIRE_BAUDRATES) - 1 - checkIncDecModel(event, DIM(CROSSFIRE_BAUDRATES) - 1 - g_eeGeneral.telemetryBaudrate, 0, DIM(CROSSFIRE_BAUDRATES) - 1);
           if (checkIncDec_Ret) {
             pauseMixerCalculations();
             pausePulses();

--- a/radio/src/gui/128x64/radio_hardware.cpp
+++ b/radio/src/gui/128x64/radio_hardware.cpp
@@ -229,10 +229,8 @@ void menuRadioHardware(event_t event)
       }
 
       case ITEM_RADIO_HARDWARE_SERIAL_BAUDRATE:
-        lcdDrawTextAlignedLeft(y, STR_MAXBAUDRATE);
-        lcdDrawNumber(HW_SETTINGS_COLUMN2, y, CROSSFIRE_BAUDRATES[g_eeGeneral.telemetryBaudrate], attr|LEFT);
+        g_eeGeneral.telemetryBaudrate = editChoice(HW_SETTINGS_COLUMN2, y, STR_MAXBAUDRATE, "\004115k400k921k1.8M3.7M", g_eeGeneral.telemetryBaudrate, 0, DIM(CROSSFIRE_BAUDRATES) - 1, attr, event);
         if (attr) {
-          g_eeGeneral.telemetryBaudrate = DIM(CROSSFIRE_BAUDRATES) - 1 - checkIncDecModel(event, DIM(CROSSFIRE_BAUDRATES) - 1 - g_eeGeneral.telemetryBaudrate, 0, DIM(CROSSFIRE_BAUDRATES) - 1);
           if (checkIncDec_Ret) {
             pauseMixerCalculations();
             pausePulses();

--- a/radio/src/gui/128x64/radio_hardware.cpp
+++ b/radio/src/gui/128x64/radio_hardware.cpp
@@ -237,7 +237,6 @@ void menuRadioHardware(event_t event)
             pauseMixerCalculations();
             pausePulses();
             EXTERNAL_MODULE_OFF();
-            storageDirty(EE_GENERAL);
             RTOS_WAIT_MS(20); // 20ms so that the pulses interrupt will reinit the frame rate
             telemetryProtocol = 255; // force telemetry port + module reinitialization
             EXTERNAL_MODULE_ON();

--- a/radio/src/storage/storage.h
+++ b/radio/src/storage/storage.h
@@ -29,6 +29,8 @@
   #define WRITE_DELAY_10MS 500
 #elif defined(PCBSKY9X) && !defined(REV0)
   #define WRITE_DELAY_10MS 500
+#elif defined(PCBI6)
+  #define WRITE_DELAY_10MS 500
 #else
   #define WRITE_DELAY_10MS 200
 #endif


### PR DESCRIPTION
- Format baud rates to make it easier to read
- **Remove marking storage as dirty** - all this fixes to how I6X shutdown works wear EEPROM, I think that instead of abusing it we need a FAQ that will clearly state that storing some of the settings require graceful shutdown